### PR TITLE
More secure twitter fix

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -7,75 +7,75 @@ Template Name: Front Page
 <?php get_header(); ?>
 
 <div class="fl-centered fl-col-mixed fl-site-wrapper">
-	<nav role="navigation" class="idi-research-clusters fl-centered fl-clearfix">
-		<div class="idi-clusters-overlay"></div>
+    <nav role="navigation" class="idi-research-clusters fl-centered fl-clearfix">
+        <div class="idi-clusters-overlay"></div>
 
-		<a class="idi-design-cluster-circle idi-cluster-circle-link idi-design-link idi-no-tab-focus" href="research/design" title="Design & Development"></a>
-		<div class="idi-cluster-circle idi-design-cluster-circle idi-design-cluster-circle-colour"></div>
-		<div class="idi-cluster-arrow idi-design-cluster-arrow"> </div>
-		<a class="idi-cluster-name idi-design-cluster-name" href="research/design">Design & Development</a>
+        <a class="idi-design-cluster-circle idi-cluster-circle-link idi-design-link idi-no-tab-focus" href="research/design" title="Design & Development"></a>
+        <div class="idi-cluster-circle idi-design-cluster-circle idi-design-cluster-circle-colour"></div>
+        <div class="idi-cluster-arrow idi-design-cluster-arrow"> </div>
+        <a class="idi-cluster-name idi-design-cluster-name" href="research/design">Design & Development</a>
 
-		<a class="idi-implementation-cluster-circle idi-implementation-link idi-cluster-circle-link idi-no-tab-focus" href="research/implementation" title="Implementation & Information Practices"></a>
-		<div class="idi-cluster-circle idi-implementation-cluster-circle idi-implementation-cluster-circle-colour"></div>
-		<div class="idi-cluster-arrow idi-implementation-cluster-arrow"> </div>
-		<a class="idi-cluster-name idi-implementation-cluster-name" href="research/implementation">Implementation & Information Practices</a>
+        <a class="idi-implementation-cluster-circle idi-implementation-link idi-cluster-circle-link idi-no-tab-focus" href="research/implementation" title="Implementation & Information Practices"></a>
+        <div class="idi-cluster-circle idi-implementation-cluster-circle idi-implementation-cluster-circle-colour"></div>
+        <div class="idi-cluster-arrow idi-implementation-cluster-arrow"> </div>
+        <a class="idi-cluster-name idi-implementation-cluster-name" href="research/implementation">Implementation & Information Practices</a>
 
-		<a class="idi-policies-cluster-circle idi-policies-link idi-cluster-circle-link idi-no-tab-focus" href="research/policies" title="Business Case, Policies, Standards & Legislation"></a>
-		<div class="idi-cluster-circle idi-policies-cluster-circle idi-policies-cluster-circle-colour"></div>
-		<div class="idi-cluster-arrow idi-policies-cluster-arrow"> </div>
-		<a class="idi-cluster-name idi-policies-cluster-name" href="research/policies">Business Case, Policies, Standards & Legislation</a>
+        <a class="idi-policies-cluster-circle idi-policies-link idi-cluster-circle-link idi-no-tab-focus" href="research/policies" title="Business Case, Policies, Standards & Legislation"></a>
+        <div class="idi-cluster-circle idi-policies-cluster-circle idi-policies-cluster-circle-colour"></div>
+        <div class="idi-cluster-arrow idi-policies-cluster-arrow"> </div>
+        <a class="idi-cluster-name idi-policies-cluster-name" href="research/policies">Business Case, Policies, Standards & Legislation</a>
 
-		<a class="idi-mobile-cluster-circle idi-mobile-link idi-cluster-circle-link idi-no-tab-focus" href="research/mobile" title="Mobile & Pervasive Computing"></a>
-		<div class="idi-cluster-circle idi-mobile-cluster-circle idi-mobile-cluster-circle-colour"></div>
-		<div class="idi-cluster-arrow idi-mobile-cluster-arrow"> </div>
-		<a class="idi-cluster-name idi-mobile-cluster-name" href="research/mobile">Mobile & Pervasive Computing</a>
-	</nav>
+        <a class="idi-mobile-cluster-circle idi-mobile-link idi-cluster-circle-link idi-no-tab-focus" href="research/mobile" title="Mobile & Pervasive Computing"></a>
+        <div class="idi-cluster-circle idi-mobile-cluster-circle idi-mobile-cluster-circle-colour"></div>
+        <div class="idi-cluster-arrow idi-mobile-cluster-arrow"> </div>
+        <a class="idi-cluster-name idi-mobile-cluster-name" href="research/mobile">Mobile & Pervasive Computing</a>
+    </nav>
 
-	<div class="fl-col-flex4 front-cols">
-		<?php
-		$the_query = new WP_Query( array('posts_per_page'=>2) );
+    <div class="fl-col-flex4 front-cols">
+        <?php
+        $the_query = new WP_Query( array('posts_per_page'=>2) );
 
-		while ($the_query->have_posts()):
-			$the_query->the_post();
-			global $more;
-			$more = 0;
-			?>
-			<div class="fl-col">
-				<div class="idi-box idi-highlight-box post">
-					<?php if(has_post_thumbnail()) {
-						the_post_thumbnail();
-					} ?>
-					<div class="idi-box-text">
-					    <h2><a class="idi-article-title" href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-				        <div class="idi-date"><?php the_time('F jS, Y') ?></div>
-			            <div class="entry">
-			                <?php the_excerpt(); ?>
-			            </div>
-					</div>
-				</div>
-			</div>
- 		<?php endwhile; ?>
+        while ($the_query->have_posts()):
+            $the_query->the_post();
+            global $more;
+            $more = 0;
+            ?>
+            <div class="fl-col">
+                <div class="idi-box idi-highlight-box post">
+                    <?php if(has_post_thumbnail()) {
+                        the_post_thumbnail();
+                    } ?>
+                    <div class="idi-box-text">
+                        <h2><a class="idi-article-title" href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                        <div class="idi-date"><?php the_time('F jS, Y') ?></div>
+                        <div class="entry">
+                            <?php the_excerpt(); ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+         <?php endwhile; ?>
 
-		<div class="fl-col">
+        <div class="fl-col">
             <?php idi_display_twitter_feed('FluidProject'); ?>
-			<?php idi_display_twitter_feed('SNOWocad'); ?>
-		</div>
+            <?php idi_display_twitter_feed('SNOWocad'); ?>
+        </div>
 
-		<div class="fl-col">
-			<?php idi_display_twitter_feed('idrc_ocadu'); ?>
+        <div class="fl-col">
+            <?php idi_display_twitter_feed('idrc_ocadu'); ?>
 
-			<div class="idi-box">
-				<div class="idi-mailing-list">
-					<?php get_template_part("mailing-list-form"); ?>
-				</div>
-				<div class="idi-box idi-box-text">
-					<?php get_template_part("institution-list"); ?>
-					<?php get_template_part("contact-info"); ?>
-				</div>
-			</div>
-		</div>
+            <div class="idi-box">
+                <div class="idi-mailing-list">
+                    <?php get_template_part("mailing-list-form"); ?>
+                </div>
+                <div class="idi-box idi-box-text">
+                    <?php get_template_part("institution-list"); ?>
+                    <?php get_template_part("contact-info"); ?>
+                </div>
+            </div>
+        </div>
 
- 	</div>
+     </div>
  </div>
 
 <?php get_footer(); ?>

--- a/front-page.php
+++ b/front-page.php
@@ -57,7 +57,7 @@ Template Name: Front Page
  		<?php endwhile; ?>
 
 		<div class="fl-col">
-			<?php idi_display_twitter_feed('FluidProject'); ?>
+            <?php idi_display_twitter_feed('FluidProject'); ?>
 			<?php idi_display_twitter_feed('SNOWocad'); ?>
 		</div>
 

--- a/functions.php
+++ b/functions.php
@@ -130,10 +130,9 @@ function panel_login_fail( $username ) {
 
 function idi_display_twitter_feed($twitter_un) {
     /*
-    We use the oAuth Twitter plugin to help us get the twitter information. 
+    We use the oAuth Twitter plugin to help us get the twitter information.
     https://wordpress.org/plugins/oauth-twitter-feed-for-developers/
     */
-
     $num_tweets = 1;
     $tweets = getTweets($num_tweets, $twitter_un);
 
@@ -145,14 +144,8 @@ function idi_display_twitter_feed($twitter_un) {
         if($tweet['text']){
             $the_tweet = $tweet['text'];
             /*
+            Format the Twitter information for output. This is a modified version of the source script. It's been changed to match our classnames and layout.
             Source: https://github.com/stormuk/storm-twitter-for-wordpress/wiki/Example-code-to-layout-tweets
-            This is a modified version of the source script. It's been changed to match our classnames and layout.
-
-            2.b. Tweet Entities within the Tweet text must be properly linked to their appropriate home on Twitter. For example:
-              i. User_mentions must link to the mentioned user's profile.
-             ii. Hashtags must link to a twitter.com search with the hashtag as the query.
-            iii. Links in Tweet text must be displayed using the display_url
-                 field in the URL entities API response, and link to the original t.co url field.
             */
 
             // i. User_mentions must link to the mentioned user's profile.
@@ -191,7 +184,7 @@ function idi_display_twitter_feed($twitter_un) {
                       <a href="https://twitter.com/'.$twitter_un.'/status/'.$tweet['id_str'].'" target="_blank">
                           '.date('h:i A M d',strtotime($tweet['created_at']. '- 4 hours')).'
                       </a>
-                  </div></li>';// -8 GMT for Pacific Standard Time
+                  </div></li>';// -4 GMT for Eastern Time
         } else {
             echo '<li><p>no tweets found</p></li>';
         }

--- a/functions.php
+++ b/functions.php
@@ -120,8 +120,8 @@ function panel_login_fail( $username ) {
     if ( !empty($referrer) && !strstr($referrer,'wp-login') && !strstr($referrer,'wp-admin') ) {
         $referrer = explode('?', $referrer);
         parse_str($referrer[1], $referrer_args);
-        unset($referrer_args['idilogout']); 	//unset old idilogout arg if set
-        $referrer_args['idilogin'] = "failed"; 	//let theme know there are errors
+        unset($referrer_args['idilogout']);     //unset old idilogout arg if set
+        $referrer_args['idilogin'] = "failed";     //let theme know there are errors
 
         wp_redirect( $referrer[0]."?".http_build_query($referrer_args) );
         exit;
@@ -136,19 +136,21 @@ function idi_display_twitter_feed($twitter_un) {
     $num_tweets = 1;
     $tweets = getTweets($num_tweets, $twitter_un);
 
-	echo '<div class="idi-box idi-highlight-box twitter-feed-group">
-				<div class="idi-box-text">
+    echo '<div class="idi-box idi-highlight-box twitter-feed-group">
+                <div class="idi-box-text">
                     <a class="twitter-follow-button" rel="external nofollow" href="http://twitter.com/'.$twitter_un.'" title="Follow @'.$twitter_un.'">@'.$twitter_un.'</a>
-					<ul>';
+                    <ul>';
     foreach($tweets as $tweet){
         if($tweet['text']){
             $the_tweet = $tweet['text'];
             /*
             Format the Twitter information for output. This is a modified version of the source script. It's been changed to match our classnames and layout.
             Source: https://github.com/stormuk/storm-twitter-for-wordpress/wiki/Example-code-to-layout-tweets
-            */
 
-            // i. User_mentions must link to the mentioned user's profile.
+
+            Convert Tweet Entities within the Tweet text to link to their URLs on Twitter. */
+
+            // Convert User_mentions to link to user profiles.
             if(is_array($tweet['entities']['user_mentions'])){
                 foreach($tweet['entities']['user_mentions'] as $key => $user_mention){
                     $the_tweet = preg_replace(
@@ -158,7 +160,7 @@ function idi_display_twitter_feed($twitter_un) {
                 }
             }
 
-            // ii. Hashtags must link to a twitter.com search with the hashtag as the query.
+            // Convert hashtag text to link to hashtag queries.
             if(is_array($tweet['entities']['hashtags'])){
                 foreach($tweet['entities']['hashtags'] as $key => $hashtag){
                     $the_tweet = preg_replace(
@@ -168,8 +170,7 @@ function idi_display_twitter_feed($twitter_un) {
                 }
             }
 
-            // iii. Links in Tweet text must be displayed using the display_url
-            //      field in the URL entities API response, and link to the original t.co url field.
+            // Convert URL text to proper links.
             if(is_array($tweet['entities']['urls'])){
                 foreach($tweet['entities']['urls'] as $key => $link){
                     $the_tweet = preg_replace(
@@ -182,9 +183,9 @@ function idi_display_twitter_feed($twitter_un) {
             echo '<li class="tweet">'.$the_tweet;
             echo '<div class="tweet-date">
                       <a href="https://twitter.com/'.$twitter_un.'/status/'.$tweet['id_str'].'" target="_blank">
-                          '.date('h:i A M d',strtotime($tweet['created_at']. '- 4 hours')).'
+                          '.get_gmt_from_date ($tweet['created_at'], 'F jS, Y g:ia').'
                       </a>
-                  </div></li>';// -4 GMT for Eastern Time
+                  </div></li>';
         } else {
             echo '<li><p>no tweets found</p></li>';
         }


### PR DESCRIPTION
Using oAuth Twitter for Developers plugin for a more secure twitter feed without API keys being made public in the PHP file.

To test:
1. Install the [oAuth Twitter Feed for Developers](https://wordpress.org/plugins/oauth-twitter-feed-for-developers/) plugin.
2. In the WP dashboard > Settings > Twitter Feed Auth, add the Twitter API keys for the IDI Site (can be found on dev.twitter.com when logged in as FluidProject). Save the changes.
3. merge the changes to the IDI-theme
4. reload IDI site and look at the index page

The old keys which were previously public are no longer valid. New keys have been generated.
